### PR TITLE
Fix crafting when table missing

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -1207,6 +1207,7 @@ export class Agent {
         this.history.add('system', `[HUD_REMINDER] Your HUD always shows the current ground truth. If earlier dialogue contradicts HUD data, always prioritize HUD.`);
         this.history.add('system', `[GOAL_REMINDER] If your history says a goal is completed, *it's completed.* Don't re-attempt or re-execute a completed goal.`);
         this.history.add('system', `[CHAT_REMINDER] Don't say the same thing twice in a row.`);
+        this.history.add('system', `[CRAFT_REMINDER] Remember to be *very* verstatile, proactive, and adaptive when crafting. If you need something, see if you can craft it from your inventory. Never give up unless you've tried everything you can think of.`);
         this.history.add('system', `[MEMORY_REMINDER] Remember to be proactive about saving owner related info, update obsolete memories, or delete duplicates or completely obsolete memories as needed.`);
 
         // Get HUD diff and add it if changes occurred

--- a/src/agent/library/skills.js
+++ b/src/agent/library/skills.js
@@ -85,6 +85,15 @@ export async function craftRecipe(bot, itemName, num = 1) {
     if (craftingTable === null) {
       // Try to place crafting table
       let hasTable = world.getInventoryCounts(bot)["crafting_table"] > 0;
+
+      // Attempt to craft a crafting table if we don't have one but may have resources
+      if (!hasTable && itemName !== "crafting_table") {
+        const craftedTable = await craftRecipe(bot, "crafting_table", 1);
+        if (craftedTable) {
+          hasTable = true;
+        }
+      }
+
       if (hasTable) {
         let pos = world.getNearestFreeSpace(bot, 1, 6);
         await placeBlock(bot, "crafting_table", pos.x, pos.y, pos.z);


### PR DESCRIPTION
## Summary
- craft a crafting table if needed when recipe requires a table

## Testing
- `npm test` *(fails: Missing script)*